### PR TITLE
Add ZEIT Now to dynamic hosting solutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ All the free ways you can host your dynamic (with backend) or static (frontend o
 1. [Surge](http://surge.sh/)
 1. [Netlify](https://www.netlify.com/) (especially for frontend projects with build step)
 1. [Github Pages](https://pages.github.com)
-1. [ZEIT Now](https://zeit.co/)
 
 #### Dynamic Sites
 
 1. [Heroku](http://heroku.com/)
 1. [AWS](https://aws.amazon.com/) (free but need card details)
 1. [Digital Ocean](https://www.digitalocean.com/) (free but need card details)
+1. [ZEIT Now](https://zeit.co/)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ All the free ways you can host your dynamic (with backend) or static (frontend o
 1. [Surge](http://surge.sh/)
 1. [Netlify](https://www.netlify.com/) (especially for frontend projects with build step)
 1. [Github Pages](https://pages.github.com)
+1. [ZEIT Now](https://zeit.co/)
 
 #### Dynamic Sites
 


### PR DESCRIPTION
Hey!

This PR adds [ZEIT Now](https://zeit.co/) to the Static Sites section of the README.

Let me know if that's okay 😄 